### PR TITLE
Naming: IResourceContractResolver -> IContractResolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ public class Comment
 
 Define your model using the Fluent builder interface.
 ```cs
-static IResourceContractResolver CreateResolver()
+static IContractResolver CreateResolver()
 {
     return new Builder()
         .With<User>("users")


### PR DESCRIPTION
Hi, I'm just working through your getting started post and think I spotted a typo.
It looks like in readme.md IResourceContractResolver should be renamed to IContractResolver.

So far I love the look of your api. I've been through all of the listed c# implementations on the JsonApi site and yours resonates the most with me. Looking forward to taking it for a test drive

Paul. 
