### PR TITLE
throw exception on startup if contract resolver is configured with a non-existent property.

### DIFF
--- a/Src/Hypermedia/Metadata/Runtime/RuntimeFieldAccessor.cs
+++ b/Src/Hypermedia/Metadata/Runtime/RuntimeFieldAccessor.cs
@@ -26,6 +26,11 @@ namespace Hypermedia.Metadata.Runtime
         {
             var property = typeof(T).GetRuntimeProperty(field);
 
+            if (property == null)
+            {
+                throw new Exception($"\"{field}\" property not found on type \"{typeof(T).FullName}\".\nCheck your contract resolver configuration.");
+            }
+
             return new RuntimeFieldAccessor(property);
         }
 

--- a/Src/Hypermedia/Metadata/Runtime/RuntimeFieldAccessor.cs
+++ b/Src/Hypermedia/Metadata/Runtime/RuntimeFieldAccessor.cs
@@ -28,7 +28,9 @@ namespace Hypermedia.Metadata.Runtime
 
             if (property == null)
             {
-                throw new Exception($"\"{field}\" property not found on type \"{typeof(T).FullName}\".\nCheck your contract resolver configuration.");
+                throw new ArgumentException(
+                    $"\"{field}\" property not found on type \"{typeof(T).FullName}\".\nCheck your contract resolver configuration.",
+                    nameof(field));
             }
 
             return new RuntimeFieldAccessor(property);


### PR DESCRIPTION
This change will aid in avoiding the situation where a contract resolver field is incorrectly configured using a non-existent property name - currently it is quite hard to diagnose the runtime exception.

To see it in action, change one of the resource configurations in the sample Startup.cs to something like `builder.With<PostResource>("posts").Id("IncorrectProperty")...`