### PR TITLE
specify include XMLDoc in build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,8 +144,3 @@ FakesAssemblies/
 
 # Node.js Tools for Visual Studio
 .ntvs_analysis.dat
-
-# XMLDoc Build Output
-*.xml
-# except any xml data in Hypermedia.Sample** folders
-!**/Hypermedia.Sample*/**/*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,8 @@ FakesAssemblies/
 
 # Node.js Tools for Visual Studio
 .ntvs_analysis.dat
+
+# XMLDoc Build Output
+*.xml
+# except any xml data in Hypermedia.Sample** folders
+!**/Hypermedia.Sample*/**/*.xml

--- a/Src/Hypermedia.AspNetCore/Hypermedia.AspNetCore.csproj
+++ b/Src/Hypermedia.AspNetCore/Hypermedia.AspNetCore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia.AspNetCore\Hypermedia.AspNetCore.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\Hypermedia.AspNetCore.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Hypermedia.AspNetCore/Hypermedia.AspNetCore.csproj
+++ b/Src/Hypermedia.AspNetCore/Hypermedia.AspNetCore.csproj
@@ -7,6 +7,10 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia.AspNetCore\Hypermedia.AspNetCore.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Json.Lite" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.3" />

--- a/Src/Hypermedia.Json/Hypermedia.Json.csproj
+++ b/Src/Hypermedia.Json/Hypermedia.Json.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia.Json\Hypermedia.Json.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\Hypermedia.Json.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Hypermedia.Json/Hypermedia.Json.csproj
+++ b/Src/Hypermedia.Json/Hypermedia.Json.csproj
@@ -15,6 +15,10 @@
       <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia.Json\Hypermedia.Json.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Json.Lite" Version="2.0.2" />
   </ItemGroup>

--- a/Src/Hypermedia.JsonApi.AspNetCore/Hypermedia.JsonApi.AspNetCore.csproj
+++ b/Src/Hypermedia.JsonApi.AspNetCore/Hypermedia.JsonApi.AspNetCore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia.JsonApi.AspNetCore\Hypermedia.JsonApi.AspNetCore.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\Hypermedia.JsonApi.AspNetCore.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Hypermedia.JsonApi.AspNetCore/Hypermedia.JsonApi.AspNetCore.csproj
+++ b/Src/Hypermedia.JsonApi.AspNetCore/Hypermedia.JsonApi.AspNetCore.csproj
@@ -7,6 +7,10 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia.JsonApi.AspNetCore\Hypermedia.JsonApi.AspNetCore.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.3" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.0.2" />

--- a/Src/Hypermedia.JsonApi.Client/Hypermedia.JsonApi.Client.csproj
+++ b/Src/Hypermedia.JsonApi.Client/Hypermedia.JsonApi.Client.csproj
@@ -13,6 +13,10 @@
     <FileVersion>2.7.0.0</FileVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia.JsonApi.Client\Hypermedia.JsonApi.Client.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
   </ItemGroup>

--- a/Src/Hypermedia.JsonApi.Client/Hypermedia.JsonApi.Client.csproj
+++ b/Src/Hypermedia.JsonApi.Client/Hypermedia.JsonApi.Client.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia.JsonApi.Client\Hypermedia.JsonApi.Client.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\Hypermedia.JsonApi.Client.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Hypermedia.JsonApi.WebApi/Hypermedia.JsonApi.WebApi.csproj
+++ b/Src/Hypermedia.JsonApi.WebApi/Hypermedia.JsonApi.WebApi.csproj
@@ -29,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Hypermedia.JsonApi.WebApi.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="JsonLite, Version=2.0.2.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Src/Hypermedia.JsonApi.WebApi/Hypermedia.JsonApi.WebApi.nuspec
+++ b/Src/Hypermedia.JsonApi.WebApi/Hypermedia.JsonApi.WebApi.nuspec
@@ -14,6 +14,11 @@
         <file src="bin\Release\Hypermedia.JsonApi.dll" target="lib\Net45" />
         <file src="bin\Release\Hypermedia.JsonApi.WebApi.dll" target="lib\Net45" />
         <file src="bin\Release\Hypermedia.WebApi.dll" target="lib\Net45" />
+        <file src="bin\Release\Hypermedia.xml" target="lib\Net45" />
+        <file src="bin\Release\Hypermedia.Json.xml" target="lib\Net45" />
+        <file src="bin\Release\Hypermedia.JsonApi.xml" target="lib\Net45" />
+        <file src="bin\Release\Hypermedia.JsonApi.WebApi.xml" target="lib\Net45" />
+        <file src="bin\Release\Hypermedia.WebApi.xml" target="lib\Net45" />
         <file src="bin\Release\JsonLite.dll" target="lib\Net45" />
     </files>
 </package>

--- a/Src/Hypermedia.JsonApi/Hypermedia.JsonApi.csproj
+++ b/Src/Hypermedia.JsonApi/Hypermedia.JsonApi.csproj
@@ -13,6 +13,10 @@
     <FileVersion>2.7.0.0</FileVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia.JsonApi\Hypermedia.JsonApi.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Json.Lite" Version="2.0.2" />
   </ItemGroup>

--- a/Src/Hypermedia.JsonApi/Hypermedia.JsonApi.csproj
+++ b/Src/Hypermedia.JsonApi/Hypermedia.JsonApi.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia.JsonApi\Hypermedia.JsonApi.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\Hypermedia.JsonApi.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Hypermedia.WebApi/Hypermedia.WebApi.csproj
+++ b/Src/Hypermedia.WebApi/Hypermedia.WebApi.csproj
@@ -29,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Hypermedia.WebApi.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="JsonLite, Version=2.0.2.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Src/Hypermedia/Hypermedia.csproj
+++ b/Src/Hypermedia/Hypermedia.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.4|AnyCPU'">
-    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia\Hypermedia.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\Hypermedia.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Hypermedia/Hypermedia.csproj
+++ b/Src/Hypermedia/Hypermedia.csproj
@@ -14,6 +14,10 @@
     <FileVersion>2.6.0.0</FileVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.4|AnyCPU'">
+    <DocumentationFile>C:\dev\windows\Hypermedia\Src\Hypermedia\Hypermedia.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Json.Lite" Version="2.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Make all those XMLDoc comments available in library consumers' intellisense. I'm not 100% across how you actually build the final nuget packages (is it just `dotnet pack ...`?), found the one nuspec file but not sure how the client package gets made.