### PR TITLE
Json property name enum support

### DIFF
--- a/Src/Hypermedia.Json/Converters/EnumConverter.cs
+++ b/Src/Hypermedia.Json/Converters/EnumConverter.cs
@@ -31,7 +31,11 @@ namespace Hypermedia.Json.Converters
         {
             var text = ((JsonString)jsonValue).Value;
 
-            return Enum.Parse(type, text, true);
+            if (Enum.TryParse(type, text, true, out object res))
+            {
+                return res;
+            }
+            return System.Text.Json.JsonSerializer.Deserialize(jsonValue.Stringify(), type);
         }
 
         /// <summary>

--- a/Src/Hypermedia.Json/Hypermedia.Json.csproj
+++ b/Src/Hypermedia.Json/Hypermedia.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>netstandard1.4</TargetFramework>
+      <TargetFramework>net6.0</TargetFramework>
       <PackageId>Hypermedia.Json</PackageId>
       <Authors>Cain O'Sullivan</Authors>
       <PackageProjectUrl>https://github.com/cosullivan/Hypermedia</PackageProjectUrl>
@@ -13,6 +13,7 @@
       <AssemblyVersion>3.3.2.0</AssemblyVersion>
       <FileVersion>3.3.2.0</FileVersion>
       <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+      <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Src/Hypermedia.JsonApi.Client/Hypermedia.JsonApi.Client.csproj
+++ b/Src/Hypermedia.JsonApi.Client/Hypermedia.JsonApi.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>3.1.3</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Cain O'Sullivan</Authors>
@@ -11,6 +11,7 @@
     <Description>A JSONAPI compatible set of extensions for the HttpClient.</Description>
     <AssemblyVersion>3.1.3.0</AssemblyVersion>
     <FileVersion>3.1.3.0</FileVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Src/Hypermedia.JsonApi/Hypermedia.JsonApi.csproj
+++ b/Src/Hypermedia.JsonApi/Hypermedia.JsonApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Cain O'Sullivan</Authors>
     <Company></Company>
@@ -11,6 +11,7 @@
     <Version>3.1.3</Version>
     <AssemblyVersion>3.1.3.0</AssemblyVersion>
     <FileVersion>3.1.2.0</FileVersion>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Src/Hypermedia/Hypermedia.csproj
+++ b/Src/Hypermedia/Hypermedia.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4</TargetFrameworks>
     <PackageId>Hypermedia.Core</PackageId>
     <Authors>Cain O'Sullivan</Authors>
     <PackageProjectUrl>https://github.com/cosullivan/Hypermedia</PackageProjectUrl>
@@ -12,6 +11,8 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <AssemblyVersion>3.1.2.0</AssemblyVersion>
     <FileVersion>3.1.2.0</FileVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
Built on #33. This is required to get access to `System.Text.Json`

Fixes #31 